### PR TITLE
Task/config index suffix

### DIFF
--- a/app.go
+++ b/app.go
@@ -57,6 +57,10 @@ func NewApp(name, desc, ver, commit, buildDate, terminalHeader, terminalFooter s
 	return &App{environment: env.NewEnv(name, desc, ver, commit, buildDate, terminalHeader, terminalFooter)}
 }
 
+func (app *App) GetEnv() *env.Env {
+	return app.environment
+}
+
 // report expvar and all metrics
 func (app *App) metricsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/core/config/system.go
+++ b/core/config/system.go
@@ -59,6 +59,8 @@ type SystemConfig struct {
 
 	CookieSecret string `config:"cookie_secret"`
 
+	AllowIndexCreation bool `config:"allow_index_creation"`
+
 	AllowMultiInstance bool `config:"allow_multi_instance"`
 
 	MaxNumOfInstance int `config:"max_num_of_instances"`

--- a/core/elastic/config.go
+++ b/core/elastic/config.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package elastic
 
-import "fmt"
+import (
+	"fmt"
+	log "github.com/cihub/seelog"
+
+)
 
 var apis = map[string]API{}
 var cfgs = map[string]ElasticsearchConfig{}
@@ -42,10 +46,33 @@ type ElasticsearchConfig struct {
 	TemplateName string `config:"template_name"`
 	IndexPrefix  string `config:"index_prefix"`
 	IndexSuffix  string `config:"index_suffix"`
+	Engine       *struct {
+		EngineID  string `json:"engineId,omitempty" config:"engine_id"`
+		AccountID string `json:"accountId,omitempty" config:"account_id"`
+	} `json:"engine,omitempty" config:"engine"`
 	BasicAuth    *struct {
 		Username string `config:"username"`
 		Password string `config:"password"`
 	} `config:"basic_auth"`
+}
+
+
+func (c* ElasticsearchConfig) Check()  {
+	
+	// Fail fast if key things are missing
+	if c.IndexPrefix == "" {
+		panic("index_prefix missing")
+	}
+	if c.Engine == nil {
+		log.Warn("engine section missing from elastic search config.")
+	} else {
+		if c.Engine.EngineID == "" {
+			panic("engine.engine_id missing from elastic search config.")
+		}
+		if c.Engine.AccountID == "" {
+			panic("engine.account_id missing from elastic search config.")
+		}
+	}
 }
 
 func GetConfig(k string) ElasticsearchConfig {

--- a/core/elastic/config.go
+++ b/core/elastic/config.go
@@ -41,6 +41,7 @@ type ElasticsearchConfig struct {
 	Endpoint     string `config:"endpoint"`
 	TemplateName string `config:"template_name"`
 	IndexPrefix  string `config:"index_prefix"`
+	IndexSuffix  string `config:"index_suffix"`
 	BasicAuth    *struct {
 		Username string `config:"username"`
 		Password string `config:"password"`

--- a/core/orm/orm.go
+++ b/core/orm/orm.go
@@ -24,6 +24,8 @@ import (
 type ORM interface {
 	RegisterSchema(t interface{}) error
 
+	RequireSchema(t interface{})
+
 	Save(o interface{}) error
 
 	Update(o interface{}) error
@@ -199,6 +201,10 @@ func GroupBy(o interface{}, selectField, groupField, haveQuery string, haveValue
 
 func RegisterSchema(t interface{}) error {
 	return getHandler().RegisterSchema(t)
+}
+
+func RequireSchema(t interface{})  {
+	getHandler().RequireSchema(t)
 }
 
 var handler ORM

--- a/modules/elastic/adapter/v0.go
+++ b/modules/elastic/adapter/v0.go
@@ -83,13 +83,13 @@ func (c *ESAPIV0) Request(method, url string, body []byte) (result *util.Result,
 }
 
 func (c *ESAPIV0) Init() {
-	c.initTemplate(c.Config.IndexPrefix)
+	c.initTemplate(c.Config.IndexPrefix, c.Config.IndexSuffix)
 }
 
-func (c *ESAPIV0) getDefaultTemplate(indexPrefix string) string {
+func (c *ESAPIV0) getDefaultTemplate(indexPrefix string, indexSuffix string) string {
 	template := `
 {
-"template": "%s*",
+"template": "%s*%s",
 "settings": {
     "number_of_shards": %v,
     "index.max_result_window":10000000
@@ -111,10 +111,10 @@ func (c *ESAPIV0) getDefaultTemplate(indexPrefix string) string {
   }
 }
 `
-	return fmt.Sprintf(template, indexPrefix, 1, TypeName6)
+	return fmt.Sprintf(template, indexPrefix, indexSuffix, 1, TypeName6)
 }
 
-func (c *ESAPIV0) initTemplate(indexPrefix string) {
+func (c *ESAPIV0) initTemplate(indexPrefix string, indexSuffix string) {
 	if global.Env().IsDebug {
 		log.Trace("init elasticsearch template")
 	}
@@ -131,7 +131,7 @@ func (c *ESAPIV0) initTemplate(indexPrefix string) {
 	}
 
 	if !exist {
-		template := c.getDefaultTemplate(indexPrefix)
+		template := c.getDefaultTemplate(indexPrefix, indexSuffix)
 		if global.Env().IsDebug {
 			log.Trace("template: ", template)
 		}
@@ -155,9 +155,7 @@ func (c *ESAPIV0) initTemplate(indexPrefix string) {
 
 // Index index a document into elasticsearch
 func (c *ESAPIV0) Index(indexName string, id interface{}, data interface{}) (*elastic.InsertResponse, error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
+	indexName = c.ToIndexName(indexName)
 	url := fmt.Sprintf("%s/%s/%s/%s", c.Config.Endpoint, indexName, TypeName6, id)
 
 	js, err := json.Marshal(data)
@@ -196,9 +194,7 @@ func (c *ESAPIV0) Index(indexName string, id interface{}, data interface{}) (*el
 
 // Get fetch document by id
 func (c *ESAPIV0) Get(indexName, id string) (*elastic.GetResponse, error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
+	indexName = c.ToIndexName(indexName)
 	url := c.Config.Endpoint + "/" + indexName + "/" + TypeName6 + "/" + id
 
 	resp, err := c.Request(util.Verb_GET, url, nil)
@@ -227,9 +223,7 @@ func (c *ESAPIV0) Get(indexName, id string) (*elastic.GetResponse, error) {
 
 // Delete used to delete document by id
 func (c *ESAPIV0) Delete(indexName, id string) (*elastic.DeleteResponse, error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
+	indexName = c.ToIndexName(indexName)
 	url := c.Config.Endpoint + "/" + indexName + "/" + TypeName6 + "/" + id
 
 	if global.Env().IsDebug {
@@ -262,11 +256,7 @@ func (c *ESAPIV0) Delete(indexName, id string) (*elastic.DeleteResponse, error) 
 
 // Count used to count how many docs in one index
 func (c *ESAPIV0) Count(indexName string) (*elastic.CountResponse, error) {
-
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
-
+	indexName = c.ToIndexName(indexName)
 	url := c.Config.Endpoint + "/" + indexName + "/_count"
 
 	if global.Env().IsDebug {
@@ -312,11 +302,7 @@ func (c *ESAPIV0) Search(indexName string, query *elastic.SearchRequest) (*elast
 }
 
 func (c *ESAPIV0) SearchWithRawQueryDSL(indexName string, queryDSL []byte) (*elastic.SearchResponse, error) {
-
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
-
+	indexName = c.ToIndexName(indexName)
 	url := c.Config.Endpoint + "/" + indexName + "/_search"
 
 	if global.Env().IsDebug {
@@ -343,10 +329,7 @@ func (c *ESAPIV0) SearchWithRawQueryDSL(indexName string, queryDSL []byte) (*ela
 }
 
 func (c *ESAPIV0) IndexExists(indexName string) (bool, error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
-
+	indexName = c.ToIndexName(indexName)
 	url := fmt.Sprintf("%s/%s", c.Config.Endpoint, indexName)
 	resp, err := c.Request(util.Verb_GET, url, nil)
 
@@ -529,9 +512,7 @@ func cleanSettings(settings map[string]interface{}) {
 }
 
 func (s *ESAPIV0) UpdateIndexSettings(name string, settings map[string]interface{}) error {
-	if s.Config.IndexPrefix != "" {
-		name = s.Config.IndexPrefix + name
-	}
+	name = s.ToIndexName(name)
 
 	if global.Env().IsDebug {
 		log.Trace("update index: ", name, ", ", settings)
@@ -578,10 +559,7 @@ func (s *ESAPIV0) UpdateIndexSettings(name string, settings map[string]interface
 }
 
 func (s *ESAPIV0) UpdateMapping(indexName string, mappings []byte) ([]byte, error) {
-	if s.Config.IndexPrefix != "" {
-		indexName = s.Config.IndexPrefix + indexName
-	}
-
+	indexName = s.ToIndexName(indexName)
 	url := fmt.Sprintf("%s/%s/%s/_mapping", s.Config.Endpoint, indexName, TypeName6)
 
 	resp, err := s.Request(util.Verb_POST, url, mappings)
@@ -596,9 +574,7 @@ func (s *ESAPIV0) UpdateMapping(indexName string, mappings []byte) ([]byte, erro
 }
 
 func (c *ESAPIV0) DeleteIndex(indexName string) (err error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
+	indexName = c.ToIndexName(indexName)
 
 	if global.Env().IsDebug {
 		log.Trace("start delete index: ", indexName)
@@ -614,10 +590,7 @@ func (c *ESAPIV0) DeleteIndex(indexName string) (err error) {
 }
 
 func (c *ESAPIV0) CreateIndex(indexName string, settings map[string]interface{}) (err error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
-
+	indexName = c.ToIndexName(indexName)
 	cleanSettings(settings)
 
 	body := bytes.Buffer{}
@@ -644,9 +617,7 @@ func (c *ESAPIV0) CreateIndex(indexName string, settings map[string]interface{})
 }
 
 func (s *ESAPIV0) Refresh(name string) (err error) {
-	if s.Config.IndexPrefix != "" {
-		name = s.Config.IndexPrefix + name
-	}
+	name = s.ToIndexName(name)
 
 	if global.Env().IsDebug {
 		log.Trace("refresh index: ", name)
@@ -781,6 +752,19 @@ func (c *ESAPIV0) PutTemplate(templateName string, template []byte) ([]byte, err
 	responseHandle(resp)
 
 	return resp.Body, nil
+}
+
+func (c *ESAPIV0) ToIndexName(indexName string) string  {
+	temp := indexName
+	if c.Config.IndexPrefix != "" {
+		temp = c.Config.IndexPrefix + temp
+	}
+
+	if c.Config.IndexSuffix != "" {
+		temp = temp + c.Config.IndexSuffix
+	}
+
+	return temp
 }
 
 func responseHandle(resp *util.Result) {

--- a/modules/elastic/adapter/v6.go
+++ b/modules/elastic/adapter/v6.go
@@ -32,13 +32,13 @@ type ESAPIV6 struct {
 }
 
 func (c *ESAPIV6) Init() {
-	c.initTemplate(c.Config.IndexPrefix)
+	c.initTemplate(c.Config.IndexPrefix, c.Config.IndexSuffix)
 }
 
-func (c *ESAPIV6) getDefaultTemplate(indexPrefix string) string {
+func (c *ESAPIV6) getDefaultTemplate(indexPrefix string, indexSuffix string) string {
 	template := `
 {
-"index_patterns": "%s*",
+"index_patterns": "%s*%s",
 "settings": {
     "number_of_shards": %v,
     "index.max_result_window":10000000
@@ -60,10 +60,10 @@ func (c *ESAPIV6) getDefaultTemplate(indexPrefix string) string {
   }
 }
 `
-	return fmt.Sprintf(template, indexPrefix, 1, TypeName6)
+	return fmt.Sprintf(template, indexPrefix, indexSuffix, 1, TypeName6)
 }
 
-func (c *ESAPIV6) initTemplate(indexPrefix string) {
+func (c *ESAPIV6) initTemplate(indexPrefix string, indexSuffix string) {
 	if global.Env().IsDebug {
 		log.Trace("init elasticsearch template")
 	}
@@ -79,7 +79,7 @@ func (c *ESAPIV6) initTemplate(indexPrefix string) {
 	}
 
 	if !exist {
-		template := c.getDefaultTemplate(indexPrefix)
+		template := c.getDefaultTemplate(indexPrefix, indexSuffix)
 		if global.Env().IsDebug {
 			log.Trace("template: ", template)
 		}

--- a/modules/elastic/adapter/v6.go
+++ b/modules/elastic/adapter/v6.go
@@ -33,6 +33,7 @@ type ESAPIV6 struct {
 
 func (c *ESAPIV6) Init() {
 	c.initTemplate(c.Config.IndexPrefix, c.Config.IndexSuffix)
+	c.Config.Check()
 }
 
 func (c *ESAPIV6) getDefaultTemplate(indexPrefix string, indexSuffix string) string {

--- a/modules/elastic/adapter/v7.go
+++ b/modules/elastic/adapter/v7.go
@@ -34,13 +34,13 @@ type ESAPIV7 struct {
 }
 
 func (c *ESAPIV7) Init() {
-	c.initTemplate(c.Config.IndexPrefix)
+	c.initTemplate(c.Config.IndexPrefix, c.Config.IndexSuffix)
 }
 
-func (c *ESAPIV7) getDefaultTemplate(indexPrefix string) string {
+func (c *ESAPIV7) getDefaultTemplate(indexPrefix string, indexSuffix string) string {
 	template := `
 {
-"index_patterns": "%s*",
+"index_patterns": "%s*%s",
 "settings": {
     "number_of_shards": %v,
     "index.max_result_window":10000000
@@ -60,10 +60,10 @@ func (c *ESAPIV7) getDefaultTemplate(indexPrefix string) string {
   }
 }
 `
-	return fmt.Sprintf(template, indexPrefix, 1)
+	return fmt.Sprintf(template, indexPrefix, indexSuffix, 1)
 }
 
-func (c *ESAPIV7) initTemplate(indexPrefix string) {
+func (c *ESAPIV7) initTemplate(indexPrefix string, indexSuffix string) {
 	if global.Env().IsDebug {
 		log.Trace("init elasticsearch template")
 	}
@@ -78,7 +78,7 @@ func (c *ESAPIV7) initTemplate(indexPrefix string) {
 		panic(err)
 	}
 	if !exist {
-		template := c.getDefaultTemplate(indexPrefix)
+		template := c.getDefaultTemplate(indexPrefix, indexSuffix)
 		log.Trace("template: ", template)
 		res, err := c.PutTemplate(templateName, []byte(template))
 		if err != nil {
@@ -96,9 +96,9 @@ const TypeName7 = "_doc"
 
 // Delete used to delete document by id
 func (c *ESAPIV7) Delete(indexName, id string) (*elastic.DeleteResponse, error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
+
+	indexName = c.ToIndexName(indexName)
+
 	url := c.Config.Endpoint + "/" + indexName + "/" + TypeName7 + "/" + id
 
 	resp, err := c.Request(util.Verb_DELETE, url, nil)
@@ -122,9 +122,9 @@ func (c *ESAPIV7) Delete(indexName, id string) (*elastic.DeleteResponse, error) 
 
 // Get fetch document by id
 func (c *ESAPIV7) Get(indexName, id string) (*elastic.GetResponse, error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
+
+	indexName = c.ToIndexName(indexName)
+
 	url := c.Config.Endpoint + "/" + indexName + "/" + TypeName7 + "/" + id
 
 	resp, err := c.Request(util.Verb_GET, url, nil)
@@ -148,9 +148,9 @@ func (c *ESAPIV7) Get(indexName, id string) (*elastic.GetResponse, error) {
 
 // IndexDoc index a document into elasticsearch
 func (c *ESAPIV7) Index(indexName string, id interface{}, data interface{}) (*elastic.InsertResponse, error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
+
+	indexName = c.ToIndexName(indexName)
+
 	url := fmt.Sprintf("%s/%s/%s/%s", c.Config.Endpoint, indexName, TypeName7, id)
 
 	js, err := json.Marshal(data)
@@ -186,9 +186,9 @@ func (c *ESAPIV7) Index(indexName string, id interface{}, data interface{}) (*el
 }
 
 func (c *ESAPIV7) UpdateMapping(indexName string, mappings []byte) ([]byte, error) {
-	if c.Config.IndexPrefix != "" {
-		indexName = c.Config.IndexPrefix + indexName
-	}
+	
+	indexName = c.ToIndexName(indexName)
+
 	if global.Env().IsDebug {
 		log.Debug("update mapping, ", indexName, ", ", string(mappings))
 	}

--- a/modules/elastic/adapter/v7.go
+++ b/modules/elastic/adapter/v7.go
@@ -35,6 +35,7 @@ type ESAPIV7 struct {
 
 func (c *ESAPIV7) Init() {
 	c.initTemplate(c.Config.IndexPrefix, c.Config.IndexSuffix)
+	c.Config.Check()
 }
 
 func (c *ESAPIV7) getDefaultTemplate(indexPrefix string, indexSuffix string) string {
@@ -153,7 +154,15 @@ func (c *ESAPIV7) Index(indexName string, id interface{}, data interface{}) (*el
 
 	url := fmt.Sprintf("%s/%s/%s/%s", c.Config.Endpoint, indexName, TypeName7, id)
 
+	data, err := c.AddEngineField(data)
+	if err != nil {
+		panic("Error decorating data with engine field.")
+	}
+
 	js, err := json.Marshal(data)
+	if err != nil {
+		panic("Error converting data to json")
+	}
 
 	if global.Env().IsDebug {
 		log.Debug("indexing doc: ", url, ",", string(js))

--- a/modules/elastic/schema.go
+++ b/modules/elastic/schema.go
@@ -67,6 +67,18 @@ func parseAnnotation(mapping []util.Annotation) string {
 	return json
 }
 
+func (handler ElasticORM) RequireSchema(t interface{}) {
+	
+	indexName := getIndexName(t)
+	exist, err := handler.Client.IndexExists(indexName)
+	if err != nil {
+		panic(err)
+	}
+	if !exist {
+		panic("Schema missing for " + indexName)
+	}
+}
+
 //elastic_mapping:"content: { type: binary, doc_values:false }"
 func (handler ElasticORM) RegisterSchema(t interface{}) error {
 


### PR DESCRIPTION
This allows both index prefix as well a suffix to be configured. The new index naming conventions require this change.

It also supports tagging all documents with an engine field.