### PR TITLE
Include engine key in kv store doc ids

### DIFF
--- a/core/elastic/api.go
+++ b/core/elastic/api.go
@@ -48,6 +48,8 @@ type API interface {
 	DeleteIndex(name string) error
 
 	Refresh(name string) (err error)
+
+	GetEngineKey() string
 }
 
 type TemplateAPI interface {

--- a/modules/elastic/adapter/v0.go
+++ b/modules/elastic/adapter/v0.go
@@ -797,6 +797,15 @@ func (c *ESAPIV0) AddEngineField(data interface{}) (interface{}, error)  {
 	return m, nil
 }
 
+func (c *ESAPIV0) GetEngineKey() string {
+	engine := c.Config.Engine
+	if engine == nil {
+		log.Info("No engine configured. Using empty key value!")
+		return ""
+	}
+	return fmt.Sprintf("%s_%s", engine.AccountID, engine.EngineID); 
+}
+
 func responseHandle(resp *util.Result) {
 	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 404 {
 		panic(errors.New(string(resp.Body)))


### PR DESCRIPTION
The key value store does not query the index, rather it does direct doc look ups by ID. It turns out this problematic because filtered aliases in elastic only apply to queries. and do not filter a _doc lookup. Furthermore the key value store doc ids, are not randomly generated. In many cases they are based off a string value such as URL. In these cases, two engines could encounter the same string value, and end up resolving the same state in the key value store. This is bad, because we need separation between engine data in the index. Hence the need for adding the engine field and the requirement that filtered aliases should be used for all operations, which showed up in the previous PR.

For example, let's say we have the key value store pointing at an index named blob. We also have filtered alias blob-asd such that the index is filtered by {engine:{engineId:100, accountId:abc}}, and filtered alias blob-jkl such that the alias is filtered by {engine: {engineId:101, accountId:abc}}. If we were to run a search (GET blob-asd/_search), we'd only get documents that had the appropriate engine fields (engineId==100). However, if we were to do a direct doc look up, (GET blob-asd/_doc/$SOMEID), we could actually get a document that does not have engine ID of 100, since the alias filter is not applicable in these situations.

The solution provided in this PR effectively encodes the engine field into the key (ie the document _id in elastic) used by the key value store. This prevents cross talk when doing lookups by doc id. 

It should be noted that other elastic.API.Get operations could potentially be plagued by a similar problem. Further testing is needed, although as long as IDs are random, it should be a non-issue.
