### PR TITLE
Adds APM to gorm and http requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ fetch-depends:
 	$(GO) get -u github.com/rs/cors
 	$(GO) get -u google.golang.org/grpc
 	$(GO) get -u golang.org/x/net/http2
+	$(GO) get -u go.elastic.co/apm/module/apmhttp
+	$(GO) get -u go.elastic.co/apm/module/apmgorm
+	$(GO) get -u go.elastic.co/apm/module/apmgorm/dialects/mysql
+	$(GO) get -u go.elastic.co/apm/module/apmgorm/dialects/sqlite
 
 test:
 	go get -u github.com/kardianos/govendor

--- a/core/util/webhunter.go
+++ b/core/util/webhunter.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io/ioutil"
-	"math"
 	"net"
 	"net/http"
 	uri "net/url"
 	"os"
 	"strings"
 	"time"
+	"math"
 
 	"crypto/tls"
 	"fmt"
@@ -317,6 +317,8 @@ type Result struct {
 	Size       uint64
 }
 
+
+
 const userAgent = "Mozilla/5.0 (compatible; DRL/1.0; +http://github.com/dan-drl/framework)"
 
 const ContentTypeJson = "application/json;charset=utf-8"
@@ -414,7 +416,7 @@ func ExecuteRequest(req *Request) (result *Result, err error) {
 		client.Transport = tbTransport
 	}
 
-	return executeWithBackoff(&(Backoff{EXP, time.Second, 0, 5}), request, req)
+	return executeWithBackoff(&(Backoff{ EXP, time.Second, 0, 5}), request, req)
 
 }
 
@@ -478,6 +480,7 @@ var httpclient = &http.Client{
 }
 var client = apmhttp.WrapClient(httpclient)
 
+
 type BackoffType int32
 
 const (
@@ -486,10 +489,10 @@ const (
 )
 
 type Backoff struct {
-	Type     BackoffType
-	Interval time.Duration
-	curTry   int
-	maxTry   int
+	Type			BackoffType
+	Interval  time.Duration
+	curTry    int
+	maxTry    int
 }
 
 func executeWithBackoff(backoff *Backoff, req *http.Request, baseReq *Request) (res *Result, err error) {
@@ -497,7 +500,7 @@ func executeWithBackoff(backoff *Backoff, req *http.Request, baseReq *Request) (
 	// Attempt to execute the request
 	res, err = executeWrapper(backoff, req, baseReq)
 
-	// If there was an error, and still under max tries limit make a recursive call to try request again.
+	// If there was an error, and still under max tries limit make a recursive call to try request again. 
 	if err != nil && backoff.curTry < backoff.maxTry {
 		log.Debugf("Recovery attempt %d of %d. Encountered error.", backoff.curTry, backoff.maxTry)
 		log.Error("Recovering from: ", err)
@@ -524,7 +527,7 @@ func executeWithBackoff(backoff *Backoff, req *http.Request, baseReq *Request) (
 func executeWrapper(backoff *Backoff, req *http.Request, baseReq *Request) (result *Result, err error) {
 	defer func() {
 
-		// As long as try is less than max allowed tries, take error from panic, and try again.
+		// As long as try is less than max allowed tries, take error from panic, and try again. 
 		// Once tries exceeds max tries, panic will bubble up and potentially crash program.
 		if backoff.curTry < backoff.maxTry {
 

--- a/plugins/persist_db/mysql/mysql.go
+++ b/plugins/persist_db/mysql/mysql.go
@@ -2,6 +2,8 @@ package mysql
 
 import (
 	"github.com/jinzhu/gorm"
+	"go.elastic.co/apm/module/apmgorm"
+	_ "go.elastic.co/apm/module/apmgorm/dialects/mysql"
 )
 
 // MySQLConfig defines mysql related config, currently only provide connection, eg: root:password@tcp(127.0.0.1:3306)/gopa?charset=utf8&parseTime=true&loc=Local
@@ -16,7 +18,7 @@ type MySQLConfig struct {
 func GetInstance(cfg *MySQLConfig) *gorm.DB {
 
 	var err error
-	db, err := gorm.Open("mysql", cfg.Connection)
+	db, err := apmgorm.Open("mysql", cfg.Connection)
 	if err != nil {
 		panic("failed to connect database")
 	}

--- a/plugins/persist_db/sqlite/sqlite.go
+++ b/plugins/persist_db/sqlite/sqlite.go
@@ -2,12 +2,10 @@ package sqlite
 
 import (
 	"fmt"
+	"github.com/dan-drl/framework/core/global"
+	"github.com/jinzhu/gorm"
 	"os"
 	"path"
-
-	"github.com/dan-drl/framework/core/global"
-
-	"github.com/jinzhu/gorm"
 	"go.elastic.co/apm/module/apmgorm"
 	_ "go.elastic.co/apm/module/apmgorm/dialects/sqlite"
 )

--- a/plugins/persist_db/sqlite/sqlite.go
+++ b/plugins/persist_db/sqlite/sqlite.go
@@ -2,10 +2,14 @@ package sqlite
 
 import (
 	"fmt"
-	"github.com/dan-drl/framework/core/global"
-	"github.com/jinzhu/gorm"
 	"os"
 	"path"
+
+	"github.com/dan-drl/framework/core/global"
+
+	"github.com/jinzhu/gorm"
+	"go.elastic.co/apm/module/apmgorm"
+	_ "go.elastic.co/apm/module/apmgorm/dialects/sqlite"
 )
 
 // SQLiteConfig currently do nothing
@@ -18,7 +22,7 @@ func GetInstance(cfg *SQLiteConfig) *gorm.DB {
 	fileName := fmt.Sprintf("file:%s?cache=shared&mode=rwc&_busy_timeout=50000000", path.Join(global.Env().GetWorkingDir(), "database/db.sqlite"))
 
 	var err error
-	db, err := gorm.Open("sqlite3", fileName)
+	db, err := apmgorm.Open("sqlite3", fileName)
 	if err != nil {
 		panic("failed to connect database")
 	}


### PR DESCRIPTION
Wraps gorm databases with APM
Wraps all http requests with APM

Ignored wrapping the API http handlers as I don't know if we use those in production.
If not we can save logs by not reporting them.
If so I can modify this request to include the handlers as well.