### PR TITLE
APM logs and pipelines with transactions and spans

### DIFF
--- a/core/logger/seelog.go
+++ b/core/logger/seelog.go
@@ -66,14 +66,11 @@ func NewLogger() seelog.LoggerInterface {
 		fmt.Println(err)
 	}
 
-	rollingFileWriter, _ := NewRollingFileWriterSize(file, rollingArchiveNone, "", 250000000, 5, rollingNameModePostfix)
-	bufferedWriter, _ := NewBufferedWriter(rollingFileWriter, 10000, 1000)
-
 	l, _ := log.LogLevelFromString(strings.ToLower(loggingConfig.LogLevel))
 	pushl, _ := log.LogLevelFromString(strings.ToLower(loggingConfig.PushLogLevel))
 
 	//logging receivers
-	receivers := []interface{}{consoleWriter, bufferedWriter}
+	receivers := []interface{}{consoleWriter}
 
 	root, err := log.NewSplitDispatcher(formatter, receivers)
 	if err != nil {

--- a/core/logger/seelog.go
+++ b/core/logger/seelog.go
@@ -17,15 +17,18 @@ limitations under the License.
 package logger
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 
+	"github.com/cihub/seelog"
 	log "github.com/cihub/seelog"
 	"github.com/dan-drl/framework/core/config"
 	"github.com/dan-drl/framework/core/env"
 	"github.com/dan-drl/framework/core/util"
 	"github.com/ryanuber/go-glob"
+	"go.elastic.co/apm"
 )
 
 var file string
@@ -33,9 +36,74 @@ var loggingConfig *config.LoggingConfig
 var l sync.Mutex
 var e *env.Env
 
+func init() {
+	err := log.RegisterCustomFormatter("APM", createAPMFormatter)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+}
+
+func createAPMFormatter(params string) log.FormatterFunc {
+	return func(message string, level log.LogLevel, logContext log.LogContextInterface) interface{} {
+		if logContext.CustomContext() != nil {
+			context := logContext.CustomContext().(context.Context)
+			if context != nil {
+				return fmt.Sprintf("[%+v]", apm.TraceFormatter(context))
+			}
+		}
+
+		return ""
+	}
+}
+
+// NewLogger create a new seelog logger based on current config
+func NewLogger() seelog.LoggerInterface {
+	consoleWriter, _ := NewConsoleWriter()
+
+	format := "[%Date(01-02) %Time] [%LEV] [%File:%Line] %APM %Msg%n"
+	formatter, err := log.NewFormatter(format)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	rollingFileWriter, _ := NewRollingFileWriterSize(file, rollingArchiveNone, "", 250000000, 5, rollingNameModePostfix)
+	bufferedWriter, _ := NewBufferedWriter(rollingFileWriter, 10000, 1000)
+
+	l, _ := log.LogLevelFromString(strings.ToLower(loggingConfig.LogLevel))
+	pushl, _ := log.LogLevelFromString(strings.ToLower(loggingConfig.PushLogLevel))
+
+	//logging receivers
+	receivers := []interface{}{consoleWriter, bufferedWriter}
+
+	root, err := log.NewSplitDispatcher(formatter, receivers)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	golbalConstraints, err := log.NewMinMaxConstraints(l, log.CriticalLvl)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	exceptions := []*log.LogLevelException{}
+
+	if loggingConfig.RealtimePushEnabled {
+		logger, err := log.LoggerFromCustomReceiver(&CustomReceiver{config: loggingConfig, minLogLevel: l, pushminLogLevel: pushl})
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			return logger
+		}
+	} else {
+		logger := log.NewAsyncLoopLogger(log.NewLoggerConfig(golbalConstraints, exceptions, root))
+		return logger
+	}
+
+	return nil
+}
+
 // SetLogging init set logging
 func SetLogging(env *env.Env, logLevel string, logFile string) {
-
 	e = env
 
 	l.Lock()
@@ -115,7 +183,6 @@ func SetLogging(env *env.Env, logLevel string, logFile string) {
 	exceptions := []*log.LogLevelException{}
 
 	if loggingConfig.RealtimePushEnabled {
-
 		logger, err := log.LoggerFromCustomReceiver(&CustomReceiver{config: loggingConfig, minLogLevel: l, pushminLogLevel: pushl})
 		err = log.ReplaceLogger(logger)
 		if err != nil {
@@ -128,7 +195,6 @@ func SetLogging(env *env.Env, logLevel string, logFile string) {
 			fmt.Println(err)
 		}
 	}
-
 }
 
 // GetLoggingConfig return logging configs

--- a/core/pipeline/context.go
+++ b/core/pipeline/context.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pipeline
 
 import (
+	"context"
 	log "github.com/cihub/seelog"
 	"github.com/dan-drl/framework/core/errors"
 	"github.com/dan-drl/framework/core/util"
@@ -32,10 +33,27 @@ type Context struct {
 	IgnoreBroken bool        `json:"ignore_broken"`
 	Payload      interface{} `json:"-"`
 
+	apmContext context.Context
+	apmLogger log.LoggerInterface
+
 	//private parameters
 	breakFlag  bool
 	exitFlag   bool
 	PipelineID string
+}
+
+// Transaction returns the apm transaction recording this pipeline context
+func (context *Context) Transaction() context.Context {
+	return context.apmContext
+}
+
+// Logger returns the logger used for linking traces with apm transactions in this pipeline context
+func (context *Context) Logger() log.LoggerInterface {
+	if context.apmLogger != nil {
+		return context.apmLogger
+	}
+
+	return log.Current
 }
 
 // End break all pipelines, but the end phrase not included

--- a/core/pipeline/pipeline.go
+++ b/core/pipeline/pipeline.go
@@ -126,7 +126,7 @@ func (pipe *Pipeline) Run() *Context {
 	pipe.context.apmContext = apmTransactionContext
 	pipe.context.apmLogger = logger.NewLogger()
 	pipe.context.apmLogger.SetContext(apmTransactionContext)
-	log := pipe.context.apmLogger
+	log := pipe.context.Logger()
 
 	stats.Increment(pipe.name+".pipeline", "total")
 
@@ -218,7 +218,7 @@ func (pipe *Pipeline) Run() *Context {
 }
 
 func (pipe *Pipeline) startPipeline() {
-	log := pipe.context.apmLogger
+	log := pipe.context.Logger()
 
 	log.Trace("start pipeline: ", pipe.name)
 	if pipe.onStartJoint != nil {
@@ -229,7 +229,7 @@ func (pipe *Pipeline) startPipeline() {
 }
 
 func (pipe *Pipeline) endPipeline() {
-	log := pipe.context.apmLogger
+	log := pipe.context.Logger()
 
 	if pipe.context.IsExit() {
 		log.Debug("exit pipeline, ", pipe.name, ", ", pipe.context.Payload)
@@ -245,7 +245,7 @@ func (pipe *Pipeline) endPipeline() {
 }
 
 func (pipe *Pipeline) handlePipelineError() {
-	log := pipe.context.apmLogger
+	log := pipe.context.Logger()
 
 	if pipe.onErrorJoint != nil {
 		log.Trace("start handle pipeline error, ", pipe.name)

--- a/core/pipeline/pipeline.go
+++ b/core/pipeline/pipeline.go
@@ -17,13 +17,19 @@ limitations under the License.
 package pipeline
 
 import (
-	log "github.com/cihub/seelog"
-	"github.com/dan-drl/framework/core/global"
-	"github.com/dan-drl/framework/core/stats"
-	"github.com/dan-drl/framework/core/util"
+	"context"
+	"errors"
 	"runtime"
 	"strings"
 	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/dan-drl/framework/core/global"
+	"github.com/dan-drl/framework/core/logger"
+	"github.com/dan-drl/framework/core/stats"
+	"github.com/dan-drl/framework/core/util"
+
+	"go.elastic.co/apm"
 )
 
 type Pipeline struct {
@@ -34,8 +40,14 @@ type Pipeline struct {
 	context      *Context
 	onEndJoint   Joint
 	onErrorJoint Joint
-
 	currentJointName string
+}
+
+type APMContextKey struct {
+	id string
+}
+type APMContextValue struct {
+	name string
 }
 
 func NewPipeline(name string) *Pipeline {
@@ -103,6 +115,18 @@ func (pipe *Pipeline) Resume() *Context {
 }
 
 func (pipe *Pipeline) Run() *Context {
+	apmContextKey := APMContextKey {
+		id: pipe.id,
+	}
+	apmContextValue := APMContextValue {
+		name: pipe.name,
+	}
+	apmTransaction := apm.DefaultTracer.StartTransaction(apmContextValue.name, "pipeline")
+	apmTransactionContext := apm.ContextWithTransaction(context.WithValue(context.Background(), apmContextKey, apmContextValue), apmTransaction)
+	pipe.context.apmContext = apmTransactionContext
+	pipe.context.apmLogger = logger.NewLogger()
+	pipe.context.apmLogger.SetContext(apmTransactionContext)
+	log := pipe.context.apmLogger
 
 	stats.Increment(pipe.name+".pipeline", "total")
 
@@ -127,6 +151,7 @@ func (pipe *Pipeline) Run() *Context {
 				//pipe.context.Set(CONTEXT_TASK_Message, util.ToJson(v, false))
 
 				log.Error("error in pipeline, ", pipe.name, ", ", pipe.id, ", ", pipe.currentJointName, ", ", v)
+				apm.CaptureError(pipe.context.apmContext, errors.New(v)).Send()
 				stats.Increment(pipe.name+".pipeline", "error")
 			}
 		}
@@ -136,6 +161,8 @@ func (pipe *Pipeline) Run() *Context {
 		}
 
 		stats.Increment(pipe.name+".pipeline", "finished")
+		
+		apmTransaction.End()
 	}()
 
 	var err error
@@ -143,10 +170,16 @@ func (pipe *Pipeline) Run() *Context {
 	pipe.startPipeline()
 
 	for _, v := range pipe.joints {
+		apmSpan, _ := apm.StartSpan(apmTransactionContext, v.Name(), "joint")
+		apmSpanContext := apm.ContextWithSpan(apmTransactionContext, apmSpan)
+		pipe.context.apmLogger.SetContext(apmSpanContext)
+		pipe.context.apmContext = apmSpanContext
+
 		log.Trace("pipe, ", pipe.name, ", start joint,", v.Name())
 		if pipe.context.IsEnd() {
 			log.Trace("break joint,", v.Name())
 			stats.Increment(pipe.name+".pipeline", "break")
+			apmSpan.End()
 			return pipe.context
 		}
 
@@ -158,6 +191,7 @@ func (pipe *Pipeline) Run() *Context {
 			}
 			log.Trace("exit joint,", v.Name())
 			stats.Increment(pipe.name+".pipeline", "exit")
+			apmSpan.End()
 			return pipe.context
 		}
 
@@ -172,15 +206,19 @@ func (pipe *Pipeline) Run() *Context {
 			log.Debugf("%s-%s: %v", pipe.name, v.Name(), err)
 			pipe.context.Payload = err.Error()
 			pipe.handlePipelineError()
+			apm.CaptureError(apmSpanContext, err).Send()
+			apmSpan.End()
 			return pipe.context
 		}
 		log.Trace(pipe.name, ", end joint,", v.Name())
+		apmSpan.End()
 	}
 
 	return pipe.context
 }
 
 func (pipe *Pipeline) startPipeline() {
+	log := pipe.context.apmLogger
 
 	log.Trace("start pipeline: ", pipe.name)
 	if pipe.onStartJoint != nil {
@@ -191,6 +229,8 @@ func (pipe *Pipeline) startPipeline() {
 }
 
 func (pipe *Pipeline) endPipeline() {
+	log := pipe.context.apmLogger
+
 	if pipe.context.IsExit() {
 		log.Debug("exit pipeline, ", pipe.name, ", ", pipe.context.Payload)
 		return
@@ -205,6 +245,7 @@ func (pipe *Pipeline) endPipeline() {
 }
 
 func (pipe *Pipeline) handlePipelineError() {
+	log := pipe.context.apmLogger
 
 	if pipe.onErrorJoint != nil {
 		log.Trace("start handle pipeline error, ", pipe.name)


### PR DESCRIPTION
Moves the apm transactions into the pipeline. 
A single pipeline run is now represented as a transaction. 
All joints are represented as a single span. 
Logs apm level errors at the joint and pipeline level.
Exposes apm configured loggers to the joints via the pipeline context.
Exposes apm transaction context to the joints via the pipeline context.