### PR TITLE
Fixes a memory leak with the apm context loggers

### DIFF
--- a/core/logger/seelog.go
+++ b/core/logger/seelog.go
@@ -70,10 +70,9 @@ func NewLogger() seelog.LoggerInterface {
 	pushl, _ := log.LogLevelFromString(strings.ToLower(loggingConfig.PushLogLevel))
 
 	rollingFileWriter, _ := NewRollingFileWriterSize(file, rollingArchiveNone, "", 250000000, 5, rollingNameModePostfix)
-	bufferedWriter, _ := NewBufferedWriter(rollingFileWriter, 10000, 1000)
 
 	//logging receivers
-	receivers := []interface{}{consoleWriter, bufferedWriter}
+	receivers := []interface{}{consoleWriter, rollingFileWriter}
 
 	root, err := log.NewSplitDispatcher(formatter, receivers)
 	if err != nil {

--- a/core/pipeline/pipeline.go
+++ b/core/pipeline/pipeline.go
@@ -128,6 +128,11 @@ func (pipe *Pipeline) Run() *Context {
 	pipe.context.apmLogger.SetContext(apmTransactionContext)
 	log := pipe.context.Logger()
 
+	defer func() {
+		pipe.context.apmLogger.Flush()
+		pipe.context.apmLogger.Close()
+	}()
+
 	stats.Increment(pipe.name+".pipeline", "total")
 
 	//final phrase


### PR DESCRIPTION
The problem stemmed from the BufferedWriter. It creates a never ending go routine that routinely blushes the write buffer. That forced every new logger to never be cleaned up by the GC. Simple fix was to switch to simply use the file writer directly and flush once the pipeline is finished.